### PR TITLE
Cast pthread_self() as uintptr_t

### DIFF
--- a/util.c
+++ b/util.c
@@ -158,7 +158,7 @@ int64_t stopWatch(struct timespec *start_time) {
 unsigned int get_seed() {
     struct timespec time;
     clock_gettime(CLOCK_THREAD_CPUTIME_ID, &time);
-    return (time.tv_sec ^ time.tv_nsec ^ (getpid() << 16) ^ pthread_self());
+    return (time.tv_sec ^ time.tv_nsec ^ (getpid() << 16) ^ (uintptr_t) pthread_self());
 }
 
 // increment target by increment in ms, if result is in the past, set target to now.


### PR DESCRIPTION
This pr fixes following compile error on Alpine 3.13:

```
util.c: In function 'get_seed':
util.c:161:59: error: invalid operands to binary ^ (have 'long int' and 'pthread_t' {aka 'struct __pthread *'})
  161 |     return (time.tv_sec ^ time.tv_nsec ^ (getpid() << 16) ^ pthread_self());
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~
      |                                        |                    |
      |                                        long int             pthread_t {aka struct __pthread *}
```