### PR TITLE
Fix compilation for bladerf

### DIFF
--- a/sdr_bladerf.c
+++ b/sdr_bladerf.c
@@ -296,8 +296,8 @@ static void *handle_bladerf_samples(struct bladerf *dev,
     MODES_NOTUSED(num_samples);
 
     // record initial time for later sys timestamp calculation
-    uint64_t entryTimestamp;
-    uint64_t microSeconds;
+    int64_t entryTimestamp;
+    int64_t microSeconds;
     milli_micro_seconds(&entryTimestamp, &microSeconds);
 
     lockReader();
@@ -418,7 +418,7 @@ static void *handle_bladerf_samples(struct bladerf *dev,
         Modes.mag_buffers[next_free_buffer].length = 0; // just in case
         Modes.first_free_buffer = next_free_buffer;
 
-        wakeDecoder();
+        wakeDecode();
         unlockReader();
     }
 

--- a/sdr_ubladerf.c
+++ b/sdr_ubladerf.c
@@ -337,9 +337,9 @@ static void *handle_bladerf_samples(struct bladerf *dev,
     MODES_NOTUSED(num_samples);
 
     // record initial time for later sys timestamp calculation
-    uint64_t entryTimestamp;
-    uint64_t microSeconds;
-    micro_milli_seconds(entryTimestamp, microSeconds);
+    int64_t entryTimestamp;
+    int64_t microSeconds;
+    milli_micro_seconds(&entryTimestamp, &microSeconds);
 
     lockReader();
     if (Modes.exit) {


### PR DESCRIPTION
Several compile errors prevent the build for bladerf. This patch adresses them.

```
$ make
cc -DMODES_READSB_VERSION=\""wiedehopf git: 60d9b28-dirty (committed: Fri Mar 11 13:39:54 2022 0100)"\" -D_GNU_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wformat -Werror=format-security -DTRACKS_UUID -DENABLE_RTLSDR -DENABLE_RTLSDR_BIASTEE -DENABLE_BLADERF -std=c11 -g -W -D_DEFAULT_SOURCE -Wall -Werror -fno-common -O2   -Wno-format-truncation -I/usr/include/ -c sdr_bladerf.c -o sdr_bladerf.o
sdr_bladerf.c: In function ‘handle_bladerf_samples’:
sdr_bladerf.c:301:25: error: pointer targets in passing argument 1 of ‘milli_micro_seconds’ differ in signedness [-Werror=pointer-sign]
  301 |     milli_micro_seconds(&entryTimestamp, &microSeconds);
      |                         ^~~~~~~~~~~~~~~
      |                         |
      |                         uint64_t * {aka long unsigned int *}
In file included from readsb.h:363,
                 from sdr_bladerf.c:24:
util.h:80:35: note: expected ‘int64_t *’ {aka ‘long int *’} but argument is of type ‘uint64_t *’ {aka ‘long unsigned int *’}
   80 | void milli_micro_seconds(int64_t *milli, int64_t *micro);
      |                          ~~~~~~~~~^~~~~
sdr_bladerf.c:301:42: error: pointer targets in passing argument 2 of ‘milli_micro_seconds’ differ in signedness [-Werror=pointer-sign]
  301 |     milli_micro_seconds(&entryTimestamp, &microSeconds);
      |                                          ^~~~~~~~~~~~~
      |                                          |
      |                                          uint64_t * {aka long unsigned int *}
In file included from readsb.h:363,
                 from sdr_bladerf.c:24:
util.h:80:51: note: expected ‘int64_t *’ {aka ‘long int *’} but argument is of type ‘uint64_t *’ {aka ‘long unsigned int *’}
   80 | void milli_micro_seconds(int64_t *milli, int64_t *micro);
      |                                          ~~~~~~~~~^~~~~
sdr_bladerf.c:421:9: error: implicit declaration of function ‘wakeDecoder’; did you mean ‘wakeDecode’? [-Werror=implicit-function-declaration]
  421 |         wakeDecoder();
      |         ^~~~~~~~~~~
      |         wakeDecode
cc1: all warnings being treated as errors
make: *** [Makefile:112: sdr_bladerf.o] Error 1

```