### PR TITLE
Add option to include all receiver IDs into aircraft.json

### DIFF
--- a/README-json.md
+++ b/README-json.md
@@ -99,6 +99,7 @@ The keys are:
    * oat, tat: outer/static air temperature (C) and total air temperature (C) are calculated from mach number and true airspeed (typically somewhat inaccurate at lower altitudes / mach numbers below 0.5, calculation is inhibited for mach < 0.395)
    * acas_ra: experimental, subject to change, see format here: https://github.com/wiedehopf/readsb/blob/ca5b8257bb6176854eb18ecd96761e107fbb12fa/json_out.c#L249
    * gpsOkBefore: experimental, subject to change: aircraft lost GPS / GPS heavily degraded, it was working well before this timestamp, only displayed for 15 min after GPS is lost / degraded
+   * seenByReceiverIds: An array of receiver ids that have provided updates for the aircraft along with their last timestamp. Only present if --aircraft-json-seen-by-list is provided.
 
 (Section references (2.2.xyz) refer to DO-260B.)
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ Don't write recent(1), full(2), either(3) traces
       --write-globe-history=<dir>
                              Extended Globe History
       --write-json=<dir>     Periodically write json output to <dir>
+      --aircraft-json-seen-by-list
+                             Write receiver ids of receivers who have seen
+                             an aircraft to aircraft.json
+      --aircraft-json-seen-by-list-timeout=<timeout>
+                             Remove receiver id from the list if there was no update
+                             for more than <timeout> seconds
+                             (int, default: 3 s, set 0 to disable timeout)
       --write-json-binCraft-only=<n>
                              Use only binary binCraft format for globe files
                              (1), for aircraft.json as well (2)

--- a/aircraft.c
+++ b/aircraft.c
@@ -124,6 +124,8 @@ void freeAircraft(struct aircraft *a) {
     }
     traceCleanup(a);
 
+    clearAircraftSeenByList(a);
+
     memset(a, 0xff, sizeof (struct aircraft));
     free(a);
 }
@@ -818,4 +820,15 @@ void updateTypeReg(struct aircraft *a) {
     ) {
         a->dbFlags |= 1;
     }
+}
+
+void clearAircraftSeenByList(struct aircraft *a)
+{
+    struct seenByReceiverIdLlEntry *current = a->seenByReceiverIds;
+    while(current) {
+        struct seenByReceiverIdLlEntry *toDelete = current;
+        current = current->next;
+        free(toDelete);
+    }
+    a->seenByReceiverIds = NULL;
 }

--- a/aircraft.h
+++ b/aircraft.h
@@ -36,6 +36,8 @@ struct aircraft *aircraftGet(uint32_t addr);
 struct aircraft *aircraftCreate(uint32_t addr);
 void freeAircraft(struct aircraft *a);
 
+void clearAircraftSeenByList(struct aircraft *a);
+
 typedef struct dbEntry {
     struct dbEntry *next;
     uint32_t addr;

--- a/help.h
+++ b/help.h
@@ -92,6 +92,8 @@ static struct argp_option optionsReadsb[] = {
     {"dcfilter", OptDcFilter, 0, OPTION_HIDDEN, "Apply a 1Hz DC filter to input data (requires more CPU)", 1},
     {"enable-biastee", OptBiasTee, 0, OPTION_HIDDEN, "Enable bias tee on supporting interfaces (default: disabled)", 1},
     {"write-json", OptJsonDir, "<dir>", 0, "Periodically write json output to <dir>", 1},
+    {"aircraft-json-seen-by-list", OptAircraftJsonSeenByList, 0, 0, "Write receiver ids of receivers who have seen an aircraft to aircraft.json", 1},
+    {"aircraft-json-seen-by-list-timeout", OptAircraftJsonSeenByListTimeout, "<timeout>", 0, "Remove receiver id from the list if there was no update for more than <timeout> seconds (int, default: 3 s, set 0 to disable timeout)", 1},
     {"write-prom", OptPromFile, "<filepath>", 0, "Periodically write prometheus output to <filepath>", 1},
     {"write-globe-history", OptGlobeHistoryDir, "<dir>", 0, "Extended Globe History", 1},
     {"write-state", OptStateDir, "<dir>", 0, "Write state to disk to have traces after a restart", 1},

--- a/json_out.h
+++ b/json_out.h
@@ -33,8 +33,9 @@ void printACASInfoShort(uint32_t addr, unsigned char *MV, struct aircraft *a, st
 void logACASInfoShort(uint32_t addr, unsigned char *MV, struct aircraft *a, struct modesMessage *mm, int64_t now);
 
 char *sprintACASInfoShort(char *p, char *end, uint32_t addr, unsigned char *MV, struct aircraft *a, struct modesMessage *mm, int64_t now);
-char *sprintAircraftObject(char *p, char *end, struct aircraft *a, int64_t now, int printMode, struct modesMessage *mm);
+char *sprintAircraftObject(char *p, char *end, struct aircraft *a, int64_t now, int printMode, struct modesMessage *mm, bool includeSeenByList);
 char *sprintAircraftRecent(char *p, char *end, struct aircraft *a, int64_t now, int printMode, struct modesMessage *mm, int64_t recent);
+size_t calculateSeenByListJsonSize(struct aircraft *a, int64_t now);
 struct char_buffer generateAircraftJson(int64_t onlyRecent);
 struct char_buffer generateAircraftBin(threadpool_buffer_t *pbuffer);
 struct char_buffer generateTraceJson(struct aircraft *a, traceBuffer tb, int start, int last, threadpool_buffer_t *buffer, int64_t startStamp);

--- a/net_io.c
+++ b/net_io.c
@@ -2204,7 +2204,7 @@ void jsonPositionOutput(struct modesMessage *mm, struct aircraft *a) {
 
     char *end = p + buflen;
 
-    p = sprintAircraftObject(p, end, a, mm->sysTimestamp, 2, NULL);
+    p = sprintAircraftObject(p, end, a, mm->sysTimestamp, 2, NULL, false);
 
     if (p + 1 < end) {
         *p++ = '\n';

--- a/readsb.c
+++ b/readsb.c
@@ -209,6 +209,8 @@ static void configSetDefaults(void) {
     Modes.messageRateMult = 1.0f;
 
     Modes.apiShutdownDelay = 0 * SECONDS;
+
+    Modes.aircraft_json_seen_by_list_timeout = 3;
 }
 //
 //=========================================================================
@@ -1464,6 +1466,12 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
             sfree(Modes.json_dir);
             Modes.json_dir = strdup(arg);
             break;
+        case OptAircraftJsonSeenByList:
+            Modes.aircraft_json_seen_by_list = 1;
+            break;
+        case OptAircraftJsonSeenByListTimeout:
+            Modes.aircraft_json_seen_by_list_timeout = atoi(arg);
+        break;
         case OptHeatmap:
             Modes.heatmap = 1;
             if (atof(arg) > 0)

--- a/readsb.h
+++ b/readsb.h
@@ -746,6 +746,8 @@ struct _Modes
     char *filename; // Input form file, --ifile option
     char *net_bind_address; // Bind address
     char *json_dir; // Path to json base directory, or NULL not to write json.
+    int8_t aircraft_json_seen_by_list;
+    int aircraft_json_seen_by_list_timeout; // Timeout in seconds
     char *globe_history_dir;
     char *state_dir;
     char *state_parent_dir;
@@ -1116,6 +1118,8 @@ enum {
     OptShowOnly,
     OptFilterDF,
     OptJsonDir,
+    OptAircraftJsonSeenByList,
+    OptAircraftJsonSeenByListTimeout,
     OptJsonGzip,
     OptJsonOnlyBin,
     OptEnableBinGz,

--- a/track.h
+++ b/track.h
@@ -304,10 +304,20 @@ struct traceCache {
     char *json;
 };
 
+struct seenByReceiverIdLlEntry {
+    struct seenByReceiverIdLlEntry *next; // Next entry
+    uint64_t receiverId;
+    uint64_t receiverId2;
+    int64_t lastTimestamp;
+};
+
 /* Structure used to describe the state of one tracked aircraft */
 struct aircraft
 {
   struct aircraft *next; // Next aircraft in our linked list
+
+  struct seenByReceiverIdLlEntry *seenByReceiverIds;
+
   uint32_t addr; // ICAO address
   addrtype_t addrtype; // highest priority address type seen for this aircraft
   int64_t seen; // Time (millis) at which the last packet with reliable address was received


### PR DESCRIPTION
This PR adds two new command line switches:
--aircraft-json-seen-by-list
--aircraft-json-seen-by-list-timeout

If --aircraft-json-seen-by-list is given, the IP addresses of remote feeders that have provided data for an aircraft will be included in the corresponding aircraft object in aircraft.json.
The --aircraft-json-seen-by-list-timeout controls how many seconds after the last update from a feeder its address will be included.