### PR TITLE
fixed inop output of 'dir' with 'closest' api call

### DIFF
--- a/api.c
+++ b/api.c
@@ -388,6 +388,7 @@ static int findInCircle(struct apiEntry *haystack, int haylen, struct apiOptions
                         matches[count] = *e;
                         *alloc += e->jsonOffset.len;
                         matches[count].distance = (float) dist;
+                        matches[count].direction = (float) bearing(lat, lon, e->bin.lat / 1E6, e->bin.lon / 1E6);
                         minDistance = dist;
                         found = true;
                     }


### PR DESCRIPTION
The json output of the `closest` api call for `dir` is always at 0.0 due to a missing line of code. 