### PR TITLE
Add support for Planefinder's proprietary protocol (port 30054)

### DIFF
--- a/help.h
+++ b/help.h
@@ -46,7 +46,7 @@ static struct argp_option optionsViewadsb[] = {
     {"quiet", OptQuiet, 0, 0, "Disable output (default)", 1},
     {"debug", OptDebug, "<flags>", 0, "Debug mode (verbose), n: network, P: CPR, S: speed check", 1},
     {0,0,0,0, "Network options:", 2},
-    {"net-connector", OptNetConnector, "<ip,port,protocol>", 0, "Establish connection, can be specified multiple times. (viewadsb default: --net-connector 127.0.0.1,30005,beast_in viewadsb first usage overrides default, second usage adds another input/output) \nProtocols: beast_out, beast_in, raw_out, raw_in, sbs_out, vrs_out, json_out, gpsd_in, uat_in", 2},
+    {"net-connector", OptNetConnector, "<ip,port,protocol>", 0, "Establish connection, can be specified multiple times. (viewadsb default: --net-connector 127.0.0.1,30005,beast_in viewadsb first usage overrides default, second usage adds another input/output) \nProtocols: beast_out, beast_in, raw_out, raw_in, sbs_out, vrs_out, json_out, gpsd_in, uat_in, planefinder_in", 2},
     {0,0,0,0, "Help options:", 100},
     { 0 }
 };
@@ -115,7 +115,7 @@ static struct argp_option optionsReadsb[] = {
     {"db-file", OptDbFile, "<file.csv.gz>", 0, "Default: \"none\" (as of writing a compatible file is available here: https://github.com/wiedehopf/tar1090-db/tree/csv)", 1},
     {"db-file-lt", OptDbFileLongtype, 0, 0, "aircraft.json: add long type as field desc, add field ownOp for the owner, add field year", 1},
     {0,0,0,0, "Network options:", 2},
-    {"net-connector", OptNetConnector, "<ip,port,protocol>", 0, "Establish connection, can be specified multiple times (e.g. 127.0.0.1,23004,beast_out) Protocols: beast_out, beast_in, raw_out, raw_in, sbs_in, sbs_in_jaero, sbs_out, sbs_out_jaero, vrs_out, json_out, gpsd_in, uat_in (one failover ip/address,port can be specified: primary-address,primary-port,protocol,failover-address,failover-port) (any position in the comma separated list can also be either silent_fail or uuid=<uuid>)", 2},
+    {"net-connector", OptNetConnector, "<ip,port,protocol>", 0, "Establish connection, can be specified multiple times (e.g. 127.0.0.1,23004,beast_out) Protocols: beast_out, beast_in, raw_out, raw_in, sbs_in, sbs_in_jaero, sbs_out, sbs_out_jaero, vrs_out, json_out, gpsd_in, uat_in, planefinder_in (one failover ip/address,port can be specified: primary-address,primary-port,protocol,failover-address,failover-port) (any position in the comma separated list can also be either silent_fail or uuid=<uuid>)", 2},
     {"net", OptNet, 0, 0, "Enable networking", 2},
     {"net-only", OptNetOnly, 0, 0, "Enable just networking, no RTL device or file used", 2},
     {"net-bind-address", OptNetBindAddr, "<ip>", 0, "IP address to bind to (default: Any; Use 127.0.0.1 for private)", 2},

--- a/net_io.c
+++ b/net_io.c
@@ -2763,6 +2763,8 @@ static int decodeBinMessage(struct client *c, char *p, int remote, int64_t now, 
 // 9-12     long        nanoseconds
 // 13-27    byte        data, mode AC/S
 static int decodePfMessage(struct client *c, char *p, int remote, int64_t now, struct messageBuffer *mb) {
+    MODES_NOTUSED(remote);
+
     int msgLen = 0;
     int j;
     unsigned char ch;
@@ -2814,9 +2816,7 @@ static int decodePfMessage(struct client *c, char *p, int remote, int64_t now, s
 
     ch = *p++; // Signal strength
     mm->signalLevel = ((unsigned char) ch / 255.0);
-    mm->signalLevel = mm->signalLevel * mm->signalLevel;
-
-    mm->remote = remote;
+    mm->signalLevel = mm->signalLevel * mm->signalLevel; // square it to get power
 
     mm->timestamp = 0;
     // Grab the timestamp (big endian format)

--- a/net_io.c
+++ b/net_io.c
@@ -2769,7 +2769,7 @@ static int decodePfMessage(struct client *c, char *p, int remote, int64_t now, s
     struct modesMessage *mm = netGetMM(mb);
     unsigned char *msg = mm->msg;
 
-#if 0
+#if 0 // MHM
     fprintf(stderr, "Parsing (first 12 bytes): ");
     for (char * byte = p; byte<=p+12; byte++) {
         fprintf(stderr, "%02x", (unsigned char)*byte & 0xFF);
@@ -2786,7 +2786,7 @@ static int decodePfMessage(struct client *c, char *p, int remote, int64_t now, s
     // Packet ID / type
     ch = *p++; /// Get the message type
     if (ch != 0xc1) {
-        fprintf(stderr, "Invalid type received: %d!\n", ch);
+        // MHM fprintf(stderr, "Invalid type received: %d!\n", ch);
         return 0;
     }
 
@@ -2833,8 +2833,6 @@ static int decodePfMessage(struct client *c, char *p, int remote, int64_t now, s
     // TODO: how do we add this? mm->timestamp += nanoseconds / 1000000000.0;
     // record reception time as the time we read it.
     mm->sysTimestamp = now;
-
-    // fprintf(stderr, "Msg timestamp is %.6f, system is %.6f\n", (double) mm->timestamp, mm->sysTimestamp / 1000.0);
 
     for (j = 0; j < msgLen; j++) { // and the data
         msg[j] = ch = *p++;
@@ -3393,7 +3391,7 @@ static int readPlanefinder(struct client *c, int64_t now, struct messageBuffer *
 
     char *start;
     char *end;
-    fprintf(stderr, "Entered readPlanefinder\n");
+    // MHM fprintf(stderr, "Entered readPlanefinder\n");
 
     // Scan the entire buffer, see if we can find one or more messages
     while (c->som < c->eod && ((p = memchr(c->som, DLE, c->eod - c->som)) != NULL)) { // The first byte of buffer 'should' be 0x10
@@ -3430,7 +3428,7 @@ static int readPlanefinder(struct client *c, int64_t now, struct messageBuffer *
         }
         // MHM fprintf(stderr, "end is 0x%p\n", end);
         if (end) {
-#if 1
+#if 0 // MHM
             fprintf(stderr, "Message found from 0x%p to 0x%p: ", c->som, end);
             for (char * byte = start; byte<=end; byte++) {
                 fprintf(stderr, "%02x", (unsigned char)*byte & 0xFF);

--- a/net_io.c
+++ b/net_io.c
@@ -2822,12 +2822,12 @@ static int decodePfMessage(struct client *c, char *p, int remote, int64_t now, s
         mm->timestamp = mm->timestamp << 8 | (ch & 255);
     }
 
-    // TODO -- add ns
-    p++;
-    p++;
-    p++;
-    p++;
-
+    long int nanoseconds = 0;
+    for (j = 0; j < 4; j++) {
+        ch = *p++;
+        nanoseconds = nanoseconds << 8 | (ch & 255);
+    }
+    // TODO: how do we add this? mm->timestamp += nanoseconds / 1000000000.0;
     // record reception time as the time we read it.
     mm->sysTimestamp = now;
 

--- a/net_io.c
+++ b/net_io.c
@@ -2757,7 +2757,7 @@ static int decodeBinMessage(struct client *c, char *p, int remote, int64_t now, 
 // 0        <DLE>
 // 1        ID          0x41
 // 2        padding     always 0
-// 3        byte        bitmask, 0 = mode AC, 1 = mode S short, 2 = mode S long, 4 = CRC. 5-7 are undefined
+// 3        byte        the lower 4 bits map to: 0 = mode AC, 1 = mode S short, 2 = mode S long. Bit 4 indicates CRC. 5-7 are undefined. (however, I see that they're being set; checking iwth them....)
 // 4        byte        signal strength
 // 5-8      long        epoch time
 // 9-12     long        nanoseconds
@@ -2793,16 +2793,16 @@ static int decodePfMessage(struct client *c, char *p, int remote, int64_t now, s
     // Padding
     p++;
 
-    // This next field is supposed to be a bitmask, but I've always seen that the bits are mutually exclusive
+    // Packet type
     ch = *p++;
-    if (ch == 0) {
-        return 0;
+    if (ch & 0x10) {
+        // TODO: CRC?
     }
-    if (ch == 0x1) {
+    if ((ch & 0xF) == 0) {
         msgLen = MODEAC_MSG_BYTES;
-    } else if (ch == 0x2) {
+    } else if ((ch & 0xF) == 1) {
         msgLen = MODES_SHORT_MSG_BYTES;
-    } else if (ch == 0x04) {
+    } else if ((ch & 0xF) == 2) {
         msgLen = MODES_LONG_MSG_BYTES;
     } else {
         fprintf(stderr, "Unknown message type: %d\n", ch);

--- a/net_io.c
+++ b/net_io.c
@@ -2823,17 +2823,19 @@ static int decodePfMessage(struct client *c, char *p, int remote, int64_t now, s
     mm->signalLevel = mm->signalLevel * mm->signalLevel; // square it to get power
 
     mm->timestamp = 0;
+    long int seconds = 0;
     for (j = 0; j < 4; j++) {
         ch = getNextPfUnstuffedByte(&p);
-        mm->timestamp = mm->timestamp << 8 | (ch & 255);
+        seconds = seconds << 8 | (ch & 255);
     }
 
-    // TODO -- what do we do with the nanosecond value? mm->timestamp is an integer...
     long int nanoseconds = 0;
     for (j = 0; j < 4; j++) {
         ch = getNextPfUnstuffedByte(&p);
         nanoseconds = nanoseconds << 8 | (ch & 255);
     }
+
+    mm->timestamp = seconds * 1000000000 + nanoseconds;
 
     // record reception time as the time we read it.
     mm->sysTimestamp = now;

--- a/net_io.c
+++ b/net_io.c
@@ -2799,6 +2799,9 @@ static int decodePfMessage(struct client *c, char *p, int remote, int64_t now, s
         // TODO: CRC?
     }
     if ((ch & 0xF) == 0) {
+        if (!Modes.mode_ac) {
+            return 0;
+        }
         msgLen = MODEAC_MSG_BYTES;
     } else if ((ch & 0xF) == 1) {
         msgLen = MODES_SHORT_MSG_BYTES;

--- a/net_io.h
+++ b/net_io.h
@@ -42,7 +42,8 @@ typedef enum
     READ_MODE_IGNORE,
     READ_MODE_BEAST,
     READ_MODE_BEAST_COMMAND,
-    READ_MODE_ASCII
+    READ_MODE_ASCII,
+    READ_MODE_PLANEFINDER
 } read_mode_t;
 
 typedef struct {

--- a/readsb.c
+++ b/readsb.c
@@ -126,6 +126,7 @@ static void configSetDefaults(void) {
     Modes.net_output_sbs_ports = strdup("0");
     Modes.net_input_sbs_ports = strdup("0");
     Modes.net_input_beast_ports = strdup("0");
+    Modes.net_input_planefinder_ports = strdup("0");
     Modes.net_output_beast_ports = strdup("0");
     Modes.net_output_beast_reduce_ports = strdup("0");
     Modes.net_output_beast_reduce_interval = 250;
@@ -1345,12 +1346,14 @@ static int make_net_connector(char *arg) {
             && strcmp(con->protocol, "feedmap_out") != 0
             && strcmp(con->protocol, "gpsd_in") != 0
             && strcmp(con->protocol, "uat_in") != 0
+            && strcmp(con->protocol, "planefinder_in") != 0
        ) {
         fprintf(stderr, "--net-connector: Unknown protocol: %s\n", con->protocol);
         fprintf(stderr, "Supported protocols: beast_out, beast_in, beast_reduce_out, beast_reduce_plus_out, raw_out, raw_in, \n"
                 "sbs_out, sbs_out_replay, sbs_out_mlat, sbs_out_jaero, \n"
                 "sbs_in, sbs_in_mlat, sbs_in_jaero, \n"
-                "vrs_out, json_out, gpsd_in, uat_in\n");
+                "vrs_out, json_out, gpsd_in, uat_in, \n"
+                "planefinder_in\n");
         return 1;
     }
     if (strcmp(con->address, "") == 0 || strcmp(con->address, "") == 0) {

--- a/readsb.h
+++ b/readsb.h
@@ -741,7 +741,7 @@ struct _Modes
     char *db_file;
     char *net_output_raw_ports; // List of raw output TCP ports
     char *net_input_raw_ports; // List of raw input TCP ports
-    char *net_input_planefinder_ports; // List of raw input TCP ports
+    char *net_input_planefinder_ports; // List of planefinder input TCP ports
     char *net_output_sbs_ports; // List of SBS output TCP ports
     char *net_input_sbs_ports; // List of SBS input TCP ports
     char *net_output_jaero_ports; // jaero SBS output ports

--- a/readsb.h
+++ b/readsb.h
@@ -741,6 +741,7 @@ struct _Modes
     char *db_file;
     char *net_output_raw_ports; // List of raw output TCP ports
     char *net_input_raw_ports; // List of raw input TCP ports
+    char *net_input_planefinder_ports; // List of raw input TCP ports
     char *net_output_sbs_ports; // List of SBS output TCP ports
     char *net_input_sbs_ports; // List of SBS input TCP ports
     char *net_output_jaero_ports; // jaero SBS output ports


### PR DESCRIPTION
This PR adds support for Planefinder's device, which outputs a custom protocol on port 30054 (tcp). The protocol wraps Mode S and Mode A/C messages in their own header, which adds a nanosecond accurate timestamp. 

The format itself is documented in the comments.

The following tasks are still outstanding:
- [ ] Decide if we should parse the nanosecond field (the device has a GPS receiver, so it's clock should be very precise)
- [x] Understand the CRC field
- [ ] Add runtime switchable debug prints (I need an example of a function that has a proper level of debug traces to know what prints to include)
- [ ] Cleanup the git commits (unless you plan to squash instead of merging)