### PR TITLE
fix: Ubuntu 24.04 package name change

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Matthias Wirth <matthias.wirth@gmail.com>
 Build-Depends: debhelper(>=9), libusb-1.0-0-dev, libncurses-dev, zlib1g-dev, zlib1g, pkg-config, libzstd-dev, libzstd1
-Build-Depends-Indep: librtlsdr0, librtlsdr-dev
+Build-Depends-Indep: librtlsdr0 | librtlsdr2, librtlsdr-dev
 Standards-Version: 4.4.0.1
 Homepage: https://github.com/wiedehopf/readsb
 Vcs-Git: https://github.com/wiedehopf/readsb.git


### PR DESCRIPTION
Adds librtlsdr2 as an alternative package version if librtlsdr0 is not available. 

As per https://www.debian.org/doc/debian-policy/ch-relationships.html

Closes: #74