### PR TITLE
interactive, uat_decode, ais_charset: disambiguate unterminated strings

### DIFF
--- a/ais_charset.c
+++ b/ais_charset.c
@@ -23,4 +23,4 @@
 
 #include "ais_charset.h"
 
-char ais_charset[64] = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";
+char ais_charset[65] = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";

--- a/ais_charset.h
+++ b/ais_charset.h
@@ -24,6 +24,6 @@
 #ifndef AIS_CHARSET_H
 #define AIS_CHARSET_H
 
-extern char ais_charset[64];
+extern char ais_charset[65];
 
 #endif

--- a/interactive.c
+++ b/interactive.c
@@ -123,7 +123,7 @@ void interactiveShowData(void) {
     static int64_t next_clear;
     int64_t now = mstime();
     char progress;
-    char spinner[4] = "|/-\\";
+    char spinner[4] __nonstring = "|/-\\";
 
     // Refresh screen every (MODES_INTERACTIVE_REFRESH_TIME) miliseconde
     if (now < next_update)

--- a/net_io.c
+++ b/net_io.c
@@ -51,6 +51,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include "ais_charset.h"
 #include "readsb.h"
 
 #include <assert.h>
@@ -208,7 +209,6 @@ static struct net_service *serviceInit(struct net_service_group *group, const ch
     return service;
 }
 
-static char *ais_charset = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";
 static uint8_t char_to_ais(int ch)
 {
     char *match;

--- a/readsb.h
+++ b/readsb.h
@@ -377,6 +377,16 @@ typedef enum {
 
 #endif
 
+// __nonstring__ is available since GCC 8 and clang 21.
+// It is possible to use the __nonstring__ attribute to
+// suppress the -Wunterminated-string-initialization warning
+// on unterminated strings (default since GCC 15)
+#if __has_attribute(__nonstring__)
+#define __nonstring __attribute__((__nonstring__))
+#else
+#define __nonstring
+#endif
+
 void setExit(int arg);
 int priorityTasksPending();
 void priorityTasksRun();

--- a/uat2esnt/uat.h
+++ b/uat2esnt/uat.h
@@ -41,4 +41,10 @@
 #define UPLINK_FRAME_DATA_BYTES (UPLINK_FRAME_DATA_BITS/8)
 #define UPLINK_FRAME_BYTES (UPLINK_FRAME_BITS/8)
 
+#if __has_attribute(__nonstring__)
+#define __nonstring __attribute__((__nonstring__))
+#else
+#define __nonstring
+#endif
+
 #endif

--- a/uat2esnt/uat2esnt.c
+++ b/uat2esnt/uat2esnt.c
@@ -486,7 +486,7 @@ static char* maybe_send_air_velocity(struct uat_adsb_mdb *mdb, char *p, char *en
 }
 
 // yeah, this could be done with a lookup table, meh.
-static char *ais_charset = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";
+static char ais_charset[65] = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";
 static uint8_t char_to_ais(int ch)
 {
     char *match;

--- a/uat2esnt/uat_decode.c
+++ b/uat2esnt/uat_decode.c
@@ -267,7 +267,7 @@ static void uat_display_sv(const struct uat_adsb_mdb *mdb, FILE *to)
             mdb->tisb_site_id);
 }
 
-static char base40_alphabet[40] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ  ..";
+static char base40_alphabet[40] __nonstring = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ  ..";
 static void uat_decode_ms(uint8_t *frame, struct uat_adsb_mdb *mdb)
 {
     uint16_t v;


### PR DESCRIPTION
GCC 15 adds -Wunterminated-string-initialization, which complains if a string is not NUL-terminated.

However, it causes false positives on byte arrays. Disambiguate that.

An alternative would be to use the [`nonstring` attribute](https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-nonstring-variable-attribute), which is available since GCC 8 and clang 21.
If you prefer using nonstring, I can adjust this Pull Request to change that.