### PR TITLE
Add default --quiet flag to reduce container logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,3 +42,4 @@ ENV LD_PRELOAD=/usr/local/lib/libjemalloc.so.2
 ENV MALLOC_CONF=narenas:1,tcache:false
 
 ENTRYPOINT ["/usr/local/bin/readsb"]
+CMD ["--quiet"]


### PR DESCRIPTION
The container was producing excessive verbose output including detailed ADS-B message decoding (CPR coordinates, altitude, ICAO addresses, etc.) which was jamming logging systems.

This change adds CMD ["--quiet"] to the Dockerfile to ensure the container runs in quiet mode by default, suppressing verbose debug output.

Users can still override this by passing additional arguments or debug flags when running the container if needed.