### PR TITLE
Fix early return bug in decodeBDS44 pressure scoring

### DIFF
--- a/comm_b.c
+++ b/comm_b.c
@@ -900,9 +900,9 @@ static int decodeBDS44(struct modesMessage *mm, bool store) {
         static_pressure = (int)static_pressure_raw;
         if (static_pressure >= 0 && static_pressure <= 2048){
             score += 11;
-            return 0;
         }
         else {
+            return 0;
         }
     }
     else if (static_pressure == 0) {


### PR DESCRIPTION
## Summary
- Fixed incorrect placement of `return 0;` in decodeBDS44 function that was breaking pressure scoring
- The early return was executing when static_pressure was in the valid range (0-2048), preventing the score from being incremented
- Moved the return statement to the else block where it belongs

## Changes
- `comm_b.c:903`: Moved `return 0;` from inside the valid pressure check to the else block

## Impact
This bug was causing valid pressure scores to be lost, affecting the overall BDS44 message decoding quality. The fix ensures that the score is properly accumulated when static pressure values are within the valid range.