### PR TITLE
Fix addrtype_t out of bounds

### DIFF
--- a/readsb.h
+++ b/readsb.h
@@ -198,7 +198,7 @@ typedef enum
 
     ADDR_MODE_A = 12, /* Mode A */
 
-    ADDR_UNKNOWN = 15/* unknown address format */
+    ADDR_UNKNOWN = 13 /* unknown address format */
 } addrtype_t;
 
 // number of types as defined above


### PR DESCRIPTION
The `addrtype_t` enum contains 14 elements, but `ADDR_UNKNOWN` is assigned a value of 15.
```c
typedef enum {
    ADDR_ADSB_ICAO = 0,
    ...
    ADDR_MODE_A = 12,

    ADDR_UNKNOWN = 15
} addrtype_t;

#define NUM_TYPES 14
```

`NUM_TYPES` is defined as 14 and is used to set the array size of `pos_by_types` in the `stats` struct and `type_counts` in the `statsCount` struct.
```c
struct stats {
    ...
    uint32_t pos_by_type[NUM_TYPES];
    ...
}
```
```c
struct statsCount {
    ...
    uint32_t type_counts[NUM_TYPES];
    ...
}
```

When `setPosition()` or `statsCountAircraft()` increments this and the `addrtype` is `ADDR_UNKNOWN`, it causes a segfault.
```c
static void setPosition(struct aircraft *a, struct modesMessage *mm, int64_t now) {
    ...
    Modes.stats_current.pos_by_type[mm->addrtype]++;
    ...
}
```
```c
void statsCountAircraft(int64_t now) {
    ...
    for (int j = 0; j < Modes.acBuckets; j++) {
        for (struct aircraft *a = Modes.aircraft[j]; a; a = a->next) {
            ...
            s->type_counts[a->addrtype]++;
            ...
        }
    }
    ...
}```
