### PR TITLE
Remove unused processedBytes in decodeEncapsulatedUAT

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -4554,8 +4554,6 @@ static int decodeEncapsulatedUAT(struct client *c, char *msg, int remote, int64_
     signalLevel = signalLevel * signalLevel;
     p++;
 
-    int processedBytes = 0;
-
     for (int j = 0; j < bytes; j++) {
         if (p >= c->eod) {
             // incomplete message
@@ -4581,7 +4579,6 @@ static int decodeEncapsulatedUAT(struct client *c, char *msg, int remote, int64_
         printHexDigit(out, *p);
         out += 2;
         p++;
-        processedBytes++;
     }
 
     out = safe_snprintf(out, end, ";");


### PR DESCRIPTION
Remove unused processedBytes in decodeEncapsulatedUAT

The variable is assigned but never read, which trips `-Werror` on newer GCC versions (observed with GCC 16.1.1 20260430 on Arch Linux).

```
net_io.c: In function ‘decodeEncapsulatedUAT’:
net_io.c:4557:9: error: variable ‘processedBytes’ set but not used [-Werror=unused-but-set-variable=]
 4557 |     int processedBytes = 0;
      |         ^~~~~~~~~~~~~~

...

cc1: all warnings being treated as errors
make: *** [Makefile:189: net_io.o] Error 1
make: *** Waiting for unfinished jobs....
==> ERROR: A failure occurred in build().
    Aborting...
error: failed to build 'readsb-wiedehopf-git-3.16.2.r0.g4c1459a-1': 
error: packages failed to build: readsb-wiedehopf-git-3.16.2.r0.g4c1459a-1
```

After this change the build is successful 