### PR TITLE
Fix sign-extension in Asterix message length parsing

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -4951,7 +4951,10 @@ static int readAsterix(struct client *c, int64_t now, struct messageBuffer *mb) 
             break;
         }
         char *p = c->som;
-        uint16_t msgLen = (*(p + 1) << 8) + *(p + 2);
+        // Cast to uint8_t before shifting to prevent sign-extension on systems
+        // where char is signed — a byte value > 127 would otherwise sign-extend
+        // to a negative int before the shift, corrupting msgLen.
+        uint16_t msgLen = ((uint8_t)*(p + 1) << 8) | (uint8_t)*(p + 2);
         if (msgLen < 3 || c->som + msgLen > c->eod) {
             // invalid or incomplete messages
             break;


### PR DESCRIPTION
(*(p+1) << 8) | *(p+2) — if char is signed on the target platform, bytes with value > 127 sign-extend to negative int before shifting, corrupting the uint16_t msgLen. Cast both bytes to uint8_t first to prevent sign extension regardless of platform char signedness.