### PR TITLE
Add --devel=sbs_category: append aircraft category as SBS field 24

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -3351,7 +3351,7 @@ static void modesSendSBSOutput(struct modesMessage *mm, struct aircraft *a, stru
     struct tm stTime_receive, stTime_now;
     int msgType;
 
-    p = prepareWrite(writer, Modes.sbs_rssi ? 250 : 200);
+    p = prepareWrite(writer, Modes.sbs_category ? 260 : (Modes.sbs_rssi ? 250 : 200));
     if (!p)
         return;
 
@@ -3560,13 +3560,24 @@ static void modesSendSBSOutput(struct modesMessage *mm, struct aircraft *a, stru
             break;
     }
 
-    if (Modes.sbs_rssi) {
-        // Field 23 is the RSSI in dBFS (if we have it).
+    if (Modes.sbs_rssi || Modes.sbs_category) {
+        // Field 23: RSSI in dBFS (if we have it).
         // signalLevel is power (unsigned char / 255)^2, range [0, 1].
         // Guard: clamp to a minimum to avoid log10(0) = -inf even if signalLevel
         // is somehow a subnormal. Anything below 1e-10 is below receiver noise floor.
-        if (mm->signalLevel > 0) {
+        if (Modes.sbs_rssi && mm->signalLevel > 0) {
             p += sprintf(p, ",%.1f", 10.0 * log10(fmax(mm->signalLevel, 1e-10)));
+        } else {
+            p += sprintf(p, ",");
+        }
+    }
+
+    if (Modes.sbs_category) {
+        // Field 24: aircraft category (A0-D7) from ADS-B identification message.
+        // Encoded as ((0x0E - metype) << 4) | mesub; output as two hex chars.
+        // Empty on message types that do not carry identification data.
+        if (mm->category_valid) {
+            p += sprintf(p, ",%02X", mm->category);
         } else {
             p += sprintf(p, ",");
         }

--- a/readsb.c
+++ b/readsb.c
@@ -2186,6 +2186,9 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
                 if (strcasecmp(token[0], "sbs_rssi") == 0) {
                     Modes.sbs_rssi = 1;
                 }
+                if (strcasecmp(token[0], "sbs_category") == 0) {
+                    Modes.sbs_category = 1;
+                }
                 if (strcasecmp(token[0], "beast_dated_dirs") == 0) {
                     Modes.beast_dated_dirs = 1;
                 }

--- a/readsb.h
+++ b/readsb.h
@@ -771,6 +771,7 @@ struct _Modes
     int8_t syntethic_now_suppress_errors;
     int8_t ifile_no_synthetic;
     int8_t sbs_rssi;
+    int8_t sbs_category; // --devel=sbs_category: append aircraft category (A0-D7) as SBS field 24
     int8_t tar1090_use_api;
     int8_t verbose;
 


### PR DESCRIPTION
## Summary

Adds a new `--devel=sbs_category` runtime flag that appends the aircraft
category as field 24 of the SBS output.

- Aircraft category (A0–D7) is decoded directly from ADS-B DF17
  identification messages (metype 1–4) — no external database or lookup
- Field 24 is emitted as a two-hex-char value (e.g. `A3`) on
  identification messages; empty on all other message types
- Field 23 (RSSI placeholder) is always emitted when `sbs_category` is
  active, populated only if `--devel=sbs_rssi` is also set — keeps
  field 24 at a fixed position regardless of whether RSSI is enabled
- Buffer allocation raised from 250 to 260 bytes when active
- Follows the same `--devel=` pattern established by `sbs_rssi`

## Usage

    --devel=sbs_category

Combined with RSSI:

    --devel=sbs_rssi --devel=sbs_category

Note: comma-separated form (`--devel=sbs_rssi,sbs_category`) does not
work — the `--devel=` parser treats the comma as a name/value separator.
Use separate flags.

## Example output (MSG,1 identification frames only)

    MSG,1,...,EXS059B ,,,,,,,,,,,0,-29.5,A3
    MSG,1,...,SRD226E ,,,,,,,,,,,0,-14.6,A1
    MSG,1,...,RYR91XZ ,,,,,,,,,,,0,-6.3,A3

Field 24 is empty on MSG types 3–8.
