### PR TITLE
Fix build with clang, plus two latent bugs it uncovered

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROGNAME=readsb
-READSB_VERSION := "$(shell echo -n `cat version`; { git show -s --format=format: && echo -n ' wiedehopf git: ' && git describe --tags --abbrev --dirty --always && git show -s --format=format:"(committed: %cd)" | tr -cd '[a-z],[A-Z],[0-9],:, ,\-,_,(,)';} || echo -n ' compiled on '`date +%y%m%d` )"
+READSB_VERSION := "$(shell printf '%s' `cat version`; { git show -s --format=format: && printf '%s' ' wiedehopf git: ' && git describe --tags --abbrev --dirty --always && git show -s --format=format:"(committed: %cd)" | tr -cd '[a-z],[A-Z],[0-9],:, ,\-,_,(,)';} || printf '%s' ' compiled on '`date +%y%m%d` )"
 
 RTLSDR ?= no
 BLADERF ?= no

--- a/globe_index.c
+++ b/globe_index.c
@@ -914,6 +914,7 @@ static int roundUp8(int value) {
 static int load_aircraft(char **p, char *end, int64_t now, threadpool_buffer_t *passbuffer, int strideStart, int strideEnd) {
     static int size_changed;
     int locked = 0;
+    int res = 0;
 
     ssize_t newSize = sizeof(struct aircraft);
 
@@ -1131,7 +1132,7 @@ static int load_aircraft(char **p, char *end, int64_t now, threadpool_buffer_t *
     }
 
 
-    int res = 0;
+    goto out;
 err:
     res = -1;
 out:

--- a/readsb.c
+++ b/readsb.c
@@ -2103,18 +2103,20 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
             Modes.netIngest = 1;
             break;
         case OptUuidFile:
-            // COMPAT note: do not error exit no matter the file validity
-            int fd = open(arg, O_RDONLY);
-            if (fd == -1) {
-                fprintf(stderr, "ERRROR: --uuid-file could not be opened! (%s)", strerror(errno));
-            } else {
-                int res = read(fd, Modes.uuid, sizeof(Modes.uuid));
-                if (res == -1) {
-                    fprintf(stderr, "ERRROR: --uuid-file could not be read! (%s)", strerror(errno));
+            {
+                // COMPAT note: do not error exit no matter the file validity
+                int fd = open(arg, O_RDONLY);
+                if (fd == -1) {
+                    fprintf(stderr, "ERRROR: --uuid-file could not be opened! (%s)", strerror(errno));
+                } else {
+                    int res = read(fd, Modes.uuid, sizeof(Modes.uuid));
+                    if (res == -1) {
+                        fprintf(stderr, "ERRROR: --uuid-file could not be read! (%s)", strerror(errno));
+                    }
+                    close(fd);
                 }
-                close(fd);
+                Modes.uuid[sizeof(Modes.uuid) - 1] = '\0';
             }
-            Modes.uuid[sizeof(Modes.uuid) - 1] = '\0';
             break;
         case OptUuid:
             strncpy(Modes.uuid, arg, sizeof(Modes.uuid));

--- a/readsb.h
+++ b/readsb.h
@@ -449,6 +449,8 @@ static inline void *mmap_or_exit(size_t size, int huge, const char *file, int li
     if (buf && huge) {
         madvise(buf, size, MADV_HUGEPAGE);
     }
+#else
+    MODES_NOTUSED(huge);
 #endif
     return buf;
 }

--- a/util.c
+++ b/util.c
@@ -1178,7 +1178,7 @@ int32_t tokenize(char **restrict stringp, char *restrict delim, char **restrict 
 }
 
 void spinLock(volatile atomic_int *lock) {
-    atomic_int expected;
+    int expected;
     int calls = 0;
     do {
         expected = 0;


### PR DESCRIPTION
`make` currently fails with clang (tested on macOS with Apple clang 21 and with GCC 15, both against `dev` at 60d576b). Each commit is independent, so feel free to take only part of this.

### 1. Two `-Werror` failures with clang

```
./readsb.h:437:51: error: unused parameter 'huge' [-Werror,-Wunused-parameter]
readsb.c:2107:13: error: label followed by a declaration is a C23 extension [-Werror,-Wc23-extensions]
```

- `mmap_or_exit()`'s `huge` parameter is only used inside `#ifdef MADV_HUGEPAGE`, so it is unused on platforms without it (macOS, *BSD).
- `case OptUuidFile:` (added in 60d576b) is followed directly by a declaration, which is only valid from C23 on.

### 2. `spinLock()` passes the wrong pointer type

C11 7.17.7.4 requires the `expected` argument of `atomic_compare_exchange_weak()` to be a pointer to the *non-atomic* type, i.e. `int *`. GCC accepts `atomic_int *` because its `__atomic` builtins are not type checked; clang rejects it.

### 3. `load_aircraft()` returns -1 on success

`int res = 0;` sits below every `goto` and directly above the `err:` label:

```c
    int res = 0;
err:
    res = -1;
out:
    ...
    return res;
```

So the normal path falls through into `err:` and returns -1 even on success, and the `goto out` in the `!Modes.keep_traces` branch jumps over the initializer entirely (which is what clang flags as `-Wsometimes-uninitialized`). Both call sites currently ignore the return value, so this is latent rather than user-visible, but the intent seems clear. Fixed by hoisting `res` to the top of the function and jumping to `out:` on success.

### 4. `echo -n` in the Makefile is not portable

On macOS `/bin/sh`, `echo -n` prints the `-n` literally:

```
readsb version: -n 3.16.15 -n  wiedehopf git: v3.16.15-9-g60d576b ...
```

`printf '%s'` behaves the same everywhere. Cosmetic and macOS-only — drop this commit if you'd rather keep the line as is.