### PR TITLE
Make 'make benchmarks' work again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ viewadsb: readsb
 	cp readsb viewadsb
 
 clean:
-	rm -f *.o uat2esnt/*.o compat/clock_gettime/*.o compat/clock_nanosleep/*.o compat/apple/*.o readsb viewadsb cprtests crctests convert_benchmark
+	rm -f *.o uat2esnt/*.o oneoff/*.o compat/clock_gettime/*.o compat/clock_nanosleep/*.o compat/apple/*.o readsb viewadsb cprtests crctests oneoff/convert_benchmark
 
 test: cprtest crctest
 
@@ -217,10 +217,10 @@ crctests: crc.c crc.h
 	$(CC) $(CFLAGS) -DCRCDEBUG -o $@ $<
 
 benchmarks: oneoff/convert_benchmark
-	./convert_benchmark
+	./oneoff/convert_benchmark
 
-oneoff/convert_benchmark: oneoff/convert_benchmark.o convert.o util.o
-	$(CC) $(CFLAGS) -o $@ $^ -lm
+oneoff/convert_benchmark: oneoff/convert_benchmark.o convert.o util.o threadpool.o $(COMPAT)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
 oneoff/decode_comm_b: oneoff/decode_comm_b.o comm_b.o ais_charset.o
 	$(CC) $(CFLAGS) -o $@ $^ -lm

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -19,6 +19,8 @@
 # include <machine/endian.h>
 # define le16toh(x) OSSwapLittleToHostInt16(x)
 # define le32toh(x) OSSwapLittleToHostInt32(x)
+# define htole16(x) OSSwapHostToLittleInt16(x)
+# define htole32(x) OSSwapHostToLittleInt32(x)
 
 #include "apple/clock_compat.h"
 #include "apple/compat.h"

--- a/oneoff/convert_benchmark.c
+++ b/oneoff/convert_benchmark.c
@@ -24,6 +24,19 @@
 
 #include "../readsb.h"
 
+// MODES_MAG_BUF_SAMPLES went away when the SDR transfer size became a runtime
+// variable (Modes.sdr_buf_samples). The benchmark has no SDR, so use the
+// default buffer size readsb starts up with: sdr_buf_size / 2, 128 kiB / 2.
+#define MODES_MAG_BUF_SAMPLES (128 * 1024 / 2)
+
+// util.o references the global Modes state and setExit(), both of which live in
+// readsb.c. We can't link readsb.o here, it has its own main().
+struct _Modes Modes;
+
+void setExit(int arg) {
+    MODES_NOTUSED(arg);
+}
+
 static void **testdata_uc8;
 static void **testdata_sc16;
 static void **testdata_sc16q11;


### PR DESCRIPTION
Follow-up to #141, independent of it. `make benchmarks` has been broken for a while; this gets it building and running again. Tested on macOS with Apple clang 21 and GCC 15; `make` and `make test` are unaffected.

### `oneoff/convert_benchmark.c` no longer compiles

0d9c323 ("make SDR transfer size a variable", Aug 2022) replaced `MODES_MAG_BUF_SAMPLES` with the runtime `Modes.sdr_buf_samples` but didn't update the benchmark:

```
oneoff/convert_benchmark.c:70:22: error: use of undeclared identifier 'MODES_MAG_BUF_SAMPLES'
```

The benchmark has no SDR, so I defined the constant locally from today's startup default (`sdr_buf_size` 128 kiB, 2 bytes per sample = 64k samples). The pre-2022 value was 256 kiB / 2; I went with the current default as the more meaningful number, but say the word if you'd rather keep the historic one.

It also needs `Modes` and `setExit()`, which `util.o` references and which live in `readsb.c` — that can't be linked in here since it has its own `main()` — so they're defined locally in the benchmark.

### The link rule is stale

Even with the object compiling, the link fails with a page of undefined symbols: the rule still lists `convert.o util.o` and `-lm`, but `util.o` has since picked up `threadpool.o`, zlib and zstd. Switched to `$(LDFLAGS) $(LIBS)` and added `threadpool.o` and `$(COMPAT)`.

### The target runs the wrong path

`benchmarks:` ran `./convert_benchmark`, but the binary is built as `oneoff/convert_benchmark`, so the target would have failed even with everything else fixed. `make clean` had the matching problem — it removed `./convert_benchmark` and left `oneoff/*.o` and the actual binary behind.

### `htole16` is missing on macOS

The Apple branch of `compat/compat.h` defines `le16toh`/`le32toh` but not the reverse, so the benchmark's `htole16()` calls fail to build. Added `htole16`/`htole32` next to them. Only the benchmark uses them today.

For reference, the result on an M-series Mac:

```
Benchmarking: UC8, no DC     2876.92M samples/second
Benchmarking: UC8, DC         343.98M samples/second
Benchmarking: SC16, no DC    1014.00M samples/second
Benchmarking: SC16, DC        351.00M samples/second
Benchmarking: SC16Q11, no DC 1027.05M samples/second
Benchmarking: SC16Q11, DC     351.36M samples/second
```