### PR TITLE
docker: retry aircraft.csv.gz fetch on transient HTTP errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=bind,source=.,target=/app/git \
     chmod +x /usr/local/bin/readsb-uuid && \
     rm -rf $READSB_BUILD_DIR && \
     mkdir -p  /usr/local/share/tar1090 && \
-    wget --tries=8 --waitretry=10 --retry-connrefused --retry-on-http-error=404,429,500,502,503,504 -O /usr/local/share/tar1090/aircraft.csv.gz https://github.com/wiedehopf/tar1090-db/raw/csv/aircraft.csv.gz && \
+    wget --tries=8 --waitretry=10 --retry-connrefused --retry-on-http-error=404,429,500,502,503,504 -O /usr/local/share/tar1090/aircraft.csv.gz https://raw.githubusercontent.com/wiedehopf/tar1090-db/csv/aircraft.csv.gz && \
     true
 
 FROM debian:bookworm-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=bind,source=.,target=/app/git \
     chmod +x /usr/local/bin/readsb-uuid && \
     rm -rf $READSB_BUILD_DIR && \
     mkdir -p  /usr/local/share/tar1090 && \
-    wget -O /usr/local/share/tar1090/aircraft.csv.gz https://github.com/wiedehopf/tar1090-db/raw/csv/aircraft.csv.gz && \
+    wget --tries=8 --waitretry=10 --retry-connrefused --retry-on-http-error=404,429,500,502,503,504 -O /usr/local/share/tar1090/aircraft.csv.gz https://github.com/wiedehopf/tar1090-db/raw/csv/aircraft.csv.gz && \
     true
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Summary
- Adds `--tries`, `--waitretry`, `--retry-connrefused`, and `--retry-on-http-error=404,429,500,502,503,504` to the `wget` fetching `aircraft.csv.gz` in the builder stage.

## Why
A downstream fork's CI hit `ERROR 404: Not Found` on this exact `wget` three times in a row over ~10 minutes, at the same step, while this repo's own scheduled build succeeded earlier the same day (2026-08-17T05:25 UTC) on presumably the same command. That pattern looks like GitHub throttling/blocking unauthenticated `raw.githubusercontent.com` fetches from shared GitHub-hosted-runner IP ranges rather than the file genuinely being missing (it exists on the `csv` branch).

`wget` does not retry on HTTP 404 by default regardless of `--tries` — it treats 404 as permanent — so a single rate-limited hit fails the entire multi-arch build. `--retry-on-http-error` forces a retry even on 404, which is safe here since the file is static and always present on that branch.

## Test plan
- [ ] CI (docker build workflow) passes on this PR